### PR TITLE
Add Chef Zero support

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -94,6 +94,16 @@ node_types:
                 # and the `client.rb` includes `validation_key` pointing to
                 # that file.
 
+                # Alternative 3: Chef Client in local mode (Chef Zero)
+                #
+                # - chef_repo (required)
+                #
+                # The `chef_repo` property should point to a `tar.gz` file
+                # that contains complete chef repository. This property can be
+                # URL (in which case file will be downloaded and extracted) or
+                # relative path (in which case archive should be uploaded with
+                # blueprint).
+
                 # Common for Solo and Client - start
                 #
                 # Either `runlist` or `runlists` property must be specified.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -36,9 +36,9 @@
 plugins:
     chef:
         executor: host_agent
-        source: https://github.com/cloudify-cosmo/cloudify-chef-plugin/archive/1.3.1.zip
+        source: https://github.com/cloudify-cosmo/cloudify-chef-plugin/archive/1.3.2.zip
         package_name: cloudify-chef-plugin
-        package_version: '1.3.1'
+        package_version: '1.3.2'
 
 node_types:
     cloudify.chef.nodes.SoftwareComponent:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ import setuptools
 setuptools.setup(
     zip_safe=False,
     name='cloudify-chef-plugin',
-    version='1.3.1',
+    version='1.3.2',
     author='ilya',
     author_email='ilya.sher@coding-knight.com',
     packages=['chef_plugin'],

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
 
 [testenv:py27]
 deps =
-    coverage==3.7.1 # this fixes issue with tox installing coverage --pre
+    coverage==3.7.1
     nose
     nose-cov
     testfixtures


### PR DESCRIPTION
This pull request adds Chef Zero (or local mode) functionality to plugin.

This functionality has been added because
- upstream suggests that solo usage should be replaced by zero and
- chef solo failed to run (and we failed to track down what exactly goes wrong).

This pull request mainly serves as a probe to gauge the interest in getting this upstream. Current implementation is not the best one, but it works for our use cases. If there is any interest in getting this upstream, we may invest a bit more time and clean up this plugin a bit more.
