### PR TITLE
Fix issue #25 of downloading cookbook tarball for chef-solo

### DIFF
--- a/chef_plugin/chef_client.py
+++ b/chef_plugin/chef_client.py
@@ -563,7 +563,7 @@ class ChefSoloManager(ChefManager):
         else:
             ctx.logger.info("Downloading Chef cookbooks from {0} to {1}"
                             .format(cc['cookbooks'], file_name))
-            data = requests.get(cc['cookbooks']).content
+            data = requests.get(cc['cookbooks'], stream=True).raw.read()
             self._sudo_write_file(file_name, data)
 
     def _get_cmd(self, runlist):


### PR DESCRIPTION
Fix https://github.com/cloudify-cosmo/cloudify-chef-plugin/issues/25.
tested in my centos 7.1 with python 2.7.5.
